### PR TITLE
fix: update shebang for windows compatibility

### DIFF
--- a/packages/mdx-to-md/src/cli.ts
+++ b/packages/mdx-to-md/src/cli.ts
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 import { basename, resolve } from "path"
 import { writeFile } from "fs/promises"
 import { mdxToMd } from "mdx-to-md"


### PR DESCRIPTION
When NPM creates wrapper scripts in `node_modules/.bin` folder, it parses the shebang line to know how to check for `node` path. In the case of Windows, it will create the wrong script and error if the shebang line is not
```bash
#!/usr/bin/env node
```

I realized that by looking at this StackOverflow answer https://stackoverflow.com/a/10398567/5405601

Here is an example of the expected wrapper from `node_modules\.bin\esbuild.cmd`
```cmd
@ECHO off
GOTO start
:find_dp0
SET dp0=%~dp0
EXIT /b
:start
SETLOCAL
CALL :find_dp0

@REM  OK: This is the correct path to check for
IF EXIST "%dp0%\node.exe" (
  SET "_prog=%dp0%\node.exe"
) ELSE (
  SET "_prog=node"
  SET PATHEXT=%PATHEXT:;.JS;=;%
)

endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\esbuild\bin\esbuild" %*
```

And here is the problem I have from `node_modules\.bin\mdx-to-md.cmd`
```cmd
@ECHO off
GOTO start
:find_dp0
SET dp0=%~dp0
EXIT /b
:start
SETLOCAL
CALL :find_dp0

@REM  Error: This is the wrong path to check for
IF EXIST "%dp0%\/bin/env.exe" (
  SET "_prog=%dp0%\/bin/env.exe"
) ELSE (
  SET "_prog=/bin/env"
  SET PATHEXT=%PATHEXT:;.JS;=;%
)

endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" node "%dp0%\..\mdx-to-md\dist\cli.js" %*
```
